### PR TITLE
feat: add Go debugging support with Delve

### DIFF
--- a/Dockerfile.go
+++ b/Dockerfile.go
@@ -1,0 +1,98 @@
+# Multi-stage build for lean production image
+# Stage 1: Build the Rust binary
+FROM rust:1.83-alpine AS builder
+
+# Install build dependencies
+RUN apk add --no-cache musl-dev
+
+# Create app directory
+WORKDIR /app
+
+# Copy manifest files
+COPY Cargo.toml Cargo.lock ./
+
+# Copy source code
+COPY src ./src
+
+# Build release binary with static linking for native architecture
+# Supports both x86_64 and aarch64 (ARM64)
+RUN cargo build --release
+
+# Stage 2: Create Go debugging runtime image
+FROM alpine:3.21
+
+# Install base dependencies
+RUN apk add --no-cache \
+    wget \
+    git \
+    gcc \
+    musl-dev \
+    && rm -rf /var/cache/apk/*
+
+# Install Go (official binary for consistent version across architectures)
+# Using Go 1.23.4 - latest stable release with excellent debugging support
+RUN cd /tmp && \
+    ARCH=$(uname -m) && \
+    if [ "$ARCH" = "x86_64" ]; then \
+        GO_ARCH="amd64"; \
+    elif [ "$ARCH" = "aarch64" ]; then \
+        GO_ARCH="arm64"; \
+    else \
+        echo "Unsupported architecture: $ARCH" && exit 1; \
+    fi && \
+    wget -q https://go.dev/dl/go1.23.4.linux-${GO_ARCH}.tar.gz && \
+    tar -C /usr/local -xzf go1.23.4.linux-${GO_ARCH}.tar.gz && \
+    rm go1.23.4.linux-${GO_ARCH}.tar.gz
+
+# Set Go environment variables
+ENV PATH="/usr/local/go/bin:${PATH}"
+ENV GOPATH="/go"
+ENV PATH="${GOPATH}/bin:${PATH}"
+
+# Install Delve (Go debugger with full DAP support)
+# Using v1.23.1 - latest stable with mature DAP implementation
+# This version is tested to work correctly with the MCP server
+RUN go install github.com/go-delve/delve/cmd/dlv@v1.23.1 && \
+    # Verify Delve installation
+    dlv version && \
+    # Clean up build cache
+    rm -rf /root/.cache /tmp/* && \
+    # Remove build tools no longer needed
+    apk del wget gcc musl-dev && \
+    rm -rf /var/cache/apk/*
+
+# Verify installation and print versions
+RUN echo "=== Go Debugger Installation ===" && \
+    echo "Go version: $(go version)" && \
+    echo "Delve version: $(dlv version)" && \
+    echo "Delve location: $(which dlv)" && \
+    echo "✅ Go 1.23.4 and Delve v1.23.1 installed successfully"
+
+# Create non-root user
+RUN addgroup -g 1000 mcpuser && \
+    adduser -D -u 1000 -G mcpuser mcpuser && \
+    # Create GOPATH directory for mcpuser
+    mkdir -p /go/bin && \
+    chown -R mcpuser:mcpuser /go
+
+# Copy binary from builder (native architecture)
+COPY --from=builder /app/target/release/debugger_mcp /usr/local/bin/debugger_mcp
+
+# Set ownership
+RUN chown mcpuser:mcpuser /usr/local/bin/debugger_mcp
+
+# Switch to non-root user
+USER mcpuser
+
+# Set working directory
+WORKDIR /workspace
+
+# Default command
+CMD ["debugger_mcp", "serve"]
+
+# Metadata
+LABEL org.opencontainers.image.title="debugger-mcp-go"
+LABEL org.opencontainers.image.description="DAP MCP Server - Go Debugging Support"
+LABEL org.opencontainers.image.source="https://github.com/Govinda-Fichtner/debugger-mcp"
+LABEL org.opencontainers.image.version="0.1.0"
+LABEL org.opencontainers.image.variant="go"


### PR DESCRIPTION
## Summary

Add Go debugging support to the debugger MCP server with Dockerfile.go.

## Changes

- **Dockerfile.go**: Multi-stage build following the pattern of existing language-specific Dockerfiles
  - Stage 1: Build Rust MCP server binary
  - Stage 2: Go 1.23.4 + Delve v1.23.1 runtime

## Technical Details

### Go Version: 1.23.4
- Latest stable release with excellent debugging support
- Multi-architecture support (x86_64 and ARM64)

### Delve Version: v1.23.1
- Latest stable release with mature DAP implementation
- Full Debug Adapter Protocol (DAP) support
- Tested to work correctly with the MCP server

### Base Image: Alpine 3.21
- Consistent with Python, Ruby, and Node.js Dockerfiles
- Minimal image size while maintaining full functionality

## Testing

All tests passed:
- ✅ Docker build successful
- ✅ Go version: go1.23.4 linux/arm64
- ✅ Delve version: 1.23.1
- ✅ Compilation: fizzbuzz-go-test program compiles successfully
- ✅ Execution: Program runs with expected bug behavior
- ✅ Delve: Starts in headless DAP mode successfully

## Validation

The Go/Delve version combination has been carefully selected to ensure proper debugging functionality, as incorrect version combinations can cause debugger issues (as learned from previous experience).

## Test Project

This Dockerfile works with the `~/projects/fizzbuzz-go-test` project created for manual testing of Go debugging capabilities.

## Related

- Completes multi-language debugging support: Python, Ruby, Node.js, Rust, and now Go
- Follows established Docker patterns for consistency