### PR TITLE
feat: auto-expand Rust collections in evaluate output

### DIFF
--- a/src/adapters/rust.rs
+++ b/src/adapters/rust.rs
@@ -96,6 +96,66 @@ pub enum CargoTargetType {
 }
 
 impl RustAdapter {
+    /// Generate LLDB init commands to load Rust's pretty-printers.
+    ///
+    /// The Rust toolchain ships LLDB formatters (lldb_lookup.py / lldb_providers.py)
+    /// that provide human-readable display of HashMap, BTreeMap, Vec, String, etc.
+    /// `rust-lldb` loads these automatically, but CodeLLDB does not.
+    ///
+    /// This method detects the active Rust toolchain's sysroot and generates
+    /// the LLDB commands to load those formatters. If the toolchain is not found,
+    /// returns empty (debugging still works, just without pretty-printing).
+    fn rust_lldb_init_commands() -> Vec<String> {
+        // Try to find Rust sysroot via rustc
+        let sysroot = std::process::Command::new("rustc")
+            .arg("--print")
+            .arg("sysroot")
+            .output()
+            .ok()
+            .and_then(|o| {
+                if o.status.success() {
+                    String::from_utf8(o.stdout)
+                        .ok()
+                        .map(|s| s.trim().to_string())
+                } else {
+                    None
+                }
+            });
+
+        let Some(sysroot) = sysroot else {
+            debug!("🦀 [RUST] Could not determine rustc sysroot, skipping LLDB formatters");
+            return vec![];
+        };
+
+        let etc_dir = format!("{}/lib/rustlib/etc", sysroot);
+        let lookup_path = format!("{}/lldb_lookup.py", etc_dir);
+        let commands_path = format!("{}/lldb_commands", etc_dir);
+
+        if !Path::new(&lookup_path).exists() {
+            debug!(
+                "🦀 [RUST] LLDB formatters not found at {}, skipping",
+                lookup_path
+            );
+            return vec![];
+        }
+
+        info!("🦀 [RUST] Loading Rust LLDB formatters from {}", etc_dir);
+
+        // Read the lldb_commands file and prepend the script import
+        let mut commands = vec![format!("command script import \"{}\"", lookup_path)];
+
+        if let Ok(contents) = std::fs::read_to_string(&commands_path) {
+            for line in contents.lines() {
+                let trimmed = line.trim();
+                if !trimmed.is_empty() && !trimmed.starts_with('#') {
+                    commands.push(trimmed.to_string());
+                }
+            }
+        }
+
+        commands
+    }
+
     /// Get CodeLLDB command path
     ///
     /// Checks multiple locations in order:
@@ -653,6 +713,13 @@ impl RustAdapter {
             "stdio": [null, null, null],
             // Explicitly set source path to help with breakpoint resolution
             "sourceMap": {".": "."},
+            // Tell CodeLLDB this is Rust — triggers auto-loading of the toolchain's
+            // LLDB formatters (lldb_lookup.py / lldb_providers.py) for HashMap, Vec,
+            // BTreeMap, String, etc. without manual initCommands.
+            "sourceLanguages": ["rust"],
+            // Also load formatters explicitly via initCommands as a fallback
+            // (e.g. if sourceLanguages isn't supported by the adapter version).
+            "initCommands": Self::rust_lldb_init_commands(),
         });
 
         // Set working directory for proper source path resolution
@@ -850,6 +917,35 @@ mod tests {
         let config = RustAdapter::launch_args(binary, &args, None, false);
 
         assert_eq!(config["args"], json!(args));
+    }
+
+    #[test]
+    fn test_launch_args_includes_init_commands() {
+        let binary = "/workspace/target/debug/fizzbuzz";
+        let args = vec![];
+        let config = RustAdapter::launch_args(binary, &args, None, false);
+
+        // initCommands should be present (may be empty if rustc not installed)
+        assert!(config["initCommands"].is_array());
+
+        // If rustc is available, formatters should be loaded
+        let commands = config["initCommands"].as_array().unwrap();
+        if !commands.is_empty() {
+            // First command should import lldb_lookup.py
+            let first = commands[0].as_str().unwrap();
+            assert!(
+                first.contains("lldb_lookup.py"),
+                "First init command should import lldb_lookup.py, got: {}",
+                first
+            );
+            // Should contain type formatter registrations
+            assert!(
+                commands
+                    .iter()
+                    .any(|c| c.as_str().unwrap().contains("category enable Rust")),
+                "Init commands should enable the Rust category"
+            );
+        }
     }
 
     // Compilation tests require rustc installed

--- a/src/dap/client.rs
+++ b/src/dap/client.rs
@@ -1300,7 +1300,65 @@ impl DapClient {
         Ok(body.stack_frames)
     }
 
+    pub async fn variables(&self, variables_reference: i32) -> Result<Vec<Variable>> {
+        let args = VariablesArguments {
+            variables_reference,
+            filter: None,
+            start: None,
+            count: None,
+        };
+
+        let response = self
+            .send_request("variables", Some(serde_json::to_value(args)?))
+            .await?;
+
+        if !response.success {
+            return Err(Error::Dap(format!(
+                "Variables failed: {:?}",
+                response.message
+            )));
+        }
+
+        #[derive(serde::Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        struct VariablesResponse {
+            variables: Vec<Variable>,
+        }
+
+        let body: VariablesResponse = response
+            .body
+            .ok_or_else(|| Error::Dap("No body in variables response".to_string()))
+            .and_then(|v| {
+                serde_json::from_value(v)
+                    .map_err(|e| Error::Dap(format!("Failed to parse variables: {}", e)))
+            })?;
+
+        Ok(body.variables)
+    }
+
     pub async fn evaluate(&self, expression: &str, frame_id: Option<i32>) -> Result<String> {
+        let (result, variables_reference) = self.evaluate_raw(expression, frame_id).await?;
+
+        // Auto-expand children when variablesReference > 0 (synthetic providers like HashMap, Vec, BTreeMap)
+        // Skip for strings — LLDB already shows the string content in the result summary
+        if variables_reference > 0 && !result.starts_with('"') {
+            match self.expand_variable(variables_reference, 2).await {
+                Ok(expanded) if !expanded.is_empty() => {
+                    return Ok(format!("{}\n{}", result, expanded));
+                }
+                _ => {}
+            }
+        }
+
+        Ok(result)
+    }
+
+    /// Raw evaluate returning both result string and variablesReference
+    pub async fn evaluate_raw(
+        &self,
+        expression: &str,
+        frame_id: Option<i32>,
+    ) -> Result<(String, i32)> {
         // If frame_id is None, get the top frame from stack trace
         let frame_id = if let Some(id) = frame_id {
             Some(id)
@@ -1325,7 +1383,7 @@ impl DapClient {
         let args = EvaluateArguments {
             expression: expression.to_string(),
             frame_id,
-            context: Some("watch".to_string()), // Use "watch" for code expression evaluation, not "repl" (LLDB commands)
+            context: Some("watch".to_string()),
         };
 
         let response = self
@@ -1340,8 +1398,11 @@ impl DapClient {
         }
 
         #[derive(serde::Deserialize)]
+        #[serde(rename_all = "camelCase")]
         struct EvaluateResponse {
             result: String,
+            #[serde(default)]
+            variables_reference: i32,
         }
 
         let body: EvaluateResponse = response
@@ -1352,7 +1413,73 @@ impl DapClient {
                     .map_err(|e| Error::Dap(format!("Failed to parse evaluate result: {}", e)))
             })?;
 
-        Ok(body.result)
+        Ok((body.result, body.variables_reference))
+    }
+
+    /// Recursively expand a variablesReference into a readable string
+    fn expand_variable(
+        &self,
+        variables_reference: i32,
+        max_depth: u32,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<String>> + Send + '_>> {
+        Box::pin(async move {
+            if max_depth == 0 || variables_reference <= 0 {
+                return Ok(String::new());
+            }
+
+            let children = self.variables(variables_reference).await?;
+            if children.is_empty() {
+                return Ok(String::new());
+            }
+
+            let mut lines = Vec::new();
+            for child in &children {
+                // Skip [[raw]] entries — internal LLDB synthetic provider detail
+                if child.name == "[raw]" {
+                    continue;
+                }
+                // Skip character-by-character string expansion (unsigned char children)
+                let type_str = child.type_.as_deref().unwrap_or("");
+                if type_str == "unsigned char" || type_str == "char" {
+                    continue;
+                }
+
+                let child_expansion = if child.variables_reference > 0 && max_depth > 1 {
+                    match self
+                        .expand_variable(child.variables_reference, max_depth - 1)
+                        .await
+                    {
+                        Ok(s) if !s.is_empty() => {
+                            let indented: String = s
+                                .lines()
+                                .map(|l| format!("  {}", l))
+                                .collect::<Vec<_>>()
+                                .join("\n");
+                            format!("\n{}", indented)
+                        }
+                        _ => String::new(),
+                    }
+                } else if child.variables_reference > 0 {
+                    " {…}".to_string()
+                } else {
+                    String::new()
+                };
+
+                if type_str.is_empty() {
+                    lines.push(format!(
+                        "  [{}]: {}{}",
+                        child.name, child.value, child_expansion
+                    ));
+                } else {
+                    lines.push(format!(
+                        "  [{}]: {} ({}){}",
+                        child.name, child.value, type_str, child_expansion
+                    ));
+                }
+            }
+
+            Ok(lines.join("\n"))
+        })
     }
 
     pub async fn disconnect(&self) -> Result<()> {

--- a/src/dap/types.rs
+++ b/src/dap/types.rs
@@ -187,6 +187,16 @@ pub struct Scope {
     pub expensive: bool,
 }
 
+/// Variables Request Arguments
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VariablesArguments {
+    pub variables_reference: i32,
+    pub filter: Option<String>,
+    pub start: Option<i32>,
+    pub count: Option<i32>,
+}
+
 /// Continue Request Arguments
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]


### PR DESCRIPTION
## Summary
- Load Rust LLDB pretty-printers (`sourceLanguages: ["rust"]` + `initCommands` fallback) so HashMap, Vec, BTreeMap, BTreeSet, String, newtypes, and enums render readable output
- Add `variables()` DAP request to fetch children of a `variablesReference`
- Enhance `evaluate()` to recursively expand synthetic children (depth 2) when `variablesReference > 0`
- Filter out `[raw]` LLDB internals and char-by-char string expansion noise
- Skip expansion when result already contains a string summary

### Before
```
block->properties → {…}
block->id → {…}
block->content → {…}
```

### After
```
block->properties → size=6
  [[0]]: ("tags", String("Y0wbfO,pgxf1,u0S"))
  [[1]]: ("priority", Integer(3))
  [[2]]: ("level", Integer(1))
  ...

block->id → {...}
  [0]: {val:"block:65ae643a-...", ...}
    [val]: "block:65ae643a-..." (alloc::string::String)

block->content → "xfZTx2 3gJ F4B25w..."
```

## Test plan
- [x] All 206 lib tests pass (`cargo test --lib`)
- [x] Tested live against Rust PBT test with HashMap, String, EntityUri (newtype), ContentType (enum)
- [ ] Test with Vec, BTreeMap, BTreeSet (formatter loads confirmed, expansion logic is type-agnostic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)